### PR TITLE
feat(clay.nvim): Add basic clay functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_size = 2
+indent_style = space

--- a/lua/clay.lua
+++ b/lua/clay.lua
@@ -1,0 +1,51 @@
+print("LOADED CLAY") -- Will stay here until plugin is ready for main branch
+
+local M = {}
+local eval = require("conjure.eval")
+local extract = require("conjure.extract")
+
+local function conj_eval(origin, code)
+  eval["eval-str"]({
+    origin = "custom-clay-wrapper",
+    code = code,
+  })
+end
+
+M.setup = function()
+  -- nothing yet
+end
+
+M.start = function()
+  local code = string.format("(require '[scicloj.clay.v2.api :as clay])")
+  conj_eval("custom-clay-wrapper", code)
+end
+
+M.start_and_render = function()
+  local source_path = vim.fn.expand("%:p")
+  local code =
+    string.format('(do (require \'[scicloj.clay.v2.api :as clay]) (clay/make! {:source-path "%s"}))', source_path)
+  conj_eval("custom-clay-wrapper", code)
+end
+
+M.eval_form = function()
+  local form_content = extract.form({ root = true }).content
+  local source_path = vim.fn.expand("%:p")
+  local code =
+    string.format('(scicloj.clay.v2.api/make! {:source-path "%s" :single-form %s})', source_path, form_content)
+
+  conj_eval("custom-clay-wrapper", code)
+end
+
+M.eval_ns = function()
+  local source_path = vim.fn.expand("%:p")
+  local code = string.format('(scicloj.clay.v2.api/make! {:source-path "%s"})', source_path)
+  conj_eval("custom-clay-wrapper", code)
+end
+
+M.eval_ns_to_hiccup = function()
+  local source_path = vim.fn.expand("%:p")
+  local code = string.format('(scicloj.clay.v2.api/make-hiccup {:source-path "%s"})', source_path)
+  conj_eval("custom-clay-wrapper", code)
+end
+
+return M


### PR DESCRIPTION
Added basic clay functions:
start -> requires clay automatically into connected REPL without a need to put [scicloj.clay.v2.api :as clay] in :require
start_and_render ->  same as start + evaluates and renders html page in browser eval_form -> evaluates and renders current form in browser eval_ns -> evaluates and renders current namespace in browser eval_ns_to_hiccup -> evaluates current namespace and prints as hiccup